### PR TITLE
fix: no type named 'thread' in namespace 'std'

### DIFF
--- a/include/AsyncLogger/Logger.hpp
+++ b/include/AsyncLogger/Logger.hpp
@@ -11,6 +11,7 @@
     #define MAKE_FORMAT_ARGS fmt::make_format_args
 #endif
 #include <functional>
+#include <thread>
 #include "concurrency/shared_queue.hpp"
 #include "LogCapture.hpp"
 #include "LogIntermediate.hpp"


### PR DESCRIPTION
Also should be updated as dependency here: https://github.com/YimMenu/YimMenuV2/blob/enhanced/cmake/async-logger.cmake